### PR TITLE
Update to stations.json

### DIFF
--- a/stations.json
+++ b/stations.json
@@ -13665,12 +13665,12 @@
             "lon": -0.5031645138036541
         }, 
         {
-            "lat": 0.0, 
+            "lat": 51.00119, 
             "tiploc": "SHAFTTH", 
             "name": "Shaftesbury Town Hall (Bus)", 
             "crs": "SWH", 
             "toc": "ZB", 
-            "lon": 0.0
+            "lon": -2.192414
         }, 
         {
             "lat": 51.28426715211149, 


### PR DESCRIPTION
Shaftesbury Town Hall was previously located in the middle of the Atlantic Ocean. Updating with data that I have, unfortunately cannot confirm what the source is. However plotting on Google Maps, produces a better location than before.